### PR TITLE
fix bug of not loading 100+ gotchis

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -412,7 +412,7 @@ export default {
     },
     async loadGotchisList() {
       const query = `query getGotchiFromWallets {
-        aavegotchis(where: {originalOwner_: {id_in: ["${this.userAddress}"]}}) {
+        aavegotchis(first: 1000, where: {originalOwner_: {id_in: ["${this.userAddress}"]}}) {
           id
           name
           kinship


### PR DESCRIPTION
Current query is limited to 100 gotchis, which leads to a bug of not loading gotchis for addresses with more than 100 gotchis.